### PR TITLE
Added a reward_range property

### DIFF
--- a/dmc2gym/wrappers.py
+++ b/dmc2gym/wrappers.py
@@ -134,6 +134,10 @@ class DMCWrapper(core.Env):
     def action_space(self):
         return self._norm_action_space
 
+    @property
+    def reward_range(self):
+        return 0, self._frame_skip
+
     def seed(self, seed):
         self._true_action_space.seed(seed)
         self._norm_action_space.seed(seed)


### PR DESCRIPTION
`gym.Env` contains a `reward_range` attribute, which is useful e.g. for normalization. Currently, this attribute is left at the default value of [-inf, inf]. In the dm_control environments, the per-step reward is always in [0, 1]. With the wrapper, the rewards are therefore in [0, frame_skip]. I added a reward_range property that reflects this.