### PR TITLE
Compatibility to numpy 1.24

### DIFF
--- a/dmc2gym/wrappers.py
+++ b/dmc2gym/wrappers.py
@@ -7,7 +7,7 @@ import numpy as np
 def _spec_to_box(spec, dtype):
     def extract_min_max(s):
         assert s.dtype == np.float64 or s.dtype == np.float32
-        dim = np.int(np.prod(s.shape))
+        dim = int(np.prod(s.shape))
         if type(s) == specs.Array:
             bound = np.inf * np.ones(dim, dtype=np.float32)
             return -bound, bound


### PR DESCRIPTION
`np.int` is [deprecated since numpy 1.20.0](https://numpy.org/devdocs/release/1.20.0-notes.html#using-the-aliases-of-builtin-types-like-np-int-is-deprecated) in favor of `int`. In numpy 1.24.0 `np.int` was removed. This PR restores compatibility to the latest numpy versions.